### PR TITLE
Provide Pony with cleaner From: contents

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -17,7 +17,7 @@ end
 post '/contact' do 
   require 'pony'
     Pony.mail(
-      :from => params[:name] + "<" + params[:email] + ">",
+      :from => params[:name] + " <" + params[:email] + ">",
       :to => settings.email_address,
       :subject => params[:name] + " has contacted you",
       :body => params[:message],


### PR DESCRIPTION
Add a space between the name and the email address in the string
provided to the Pony email library, so that it cleanly encodes the
From header. Currently, it is misunderstood by some mail clients.
